### PR TITLE
Capitalize product name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "icememe",
   "version": "0.0.1",
   "description": "A meme sharing site",
-  "productName": "icememe",
+  "productName": "ICEMEME",
   "cordovaId": "org.cordova.quasar.app",
   "author": "SENG 513 W19 Group 11",
   "private": true,


### PR DESCRIPTION
Causes the HTML title element to contain "ICEMEME" in all caps.