### PR TITLE
Enforce HTTPS when in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "connect-history-api-fallback": "^1.6.0",
     "dotenv": "^7.0.0",
     "express": "^4.16.4",
+    "express-sslify": "^1.2.0",
     "knex": "^0.16.3",
     "nodemon": "^1.18.10",
     "pg": "^7.9.0",

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -1,6 +1,7 @@
 // import modules
 const express = require('express');
 const serveStatic = require('serve-static');
+const enforce = require('express-sslify');
 const history = require('connect-history-api-fallback');
 const path = require('path');
 require('dotenv').config();
@@ -9,6 +10,11 @@ require('dotenv').config();
 const port = process.env.NODE_ENV === 'production' ? process.env.PORT || 5000 : 5000;
 const app = express();
 const server = require('http').createServer(app);
+
+// enforce HTTPS in production
+if (process.env.NODE_ENV === 'production') {
+  app.use(enforce.HTTPS({ trustProtoHeader: true }));
+}
 
 // connect socket.io
 const io = require('socket.io')(server);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,6 +3214,11 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+express-sslify@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/express-sslify/-/express-sslify-1.2.0.tgz#30e84bceed1557eb187672bbe1430a0a2a100d9c"
+  integrity sha1-MOhLzu0VV+sYdnK74UMKCioQDZw=
+
 express@4.16.4, express@^4.16.2, express@^4.16.3, express@^4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"


### PR DESCRIPTION
This will upgrade HTTP connections to HTTPS. It is configured to detect HTTP connections from behind a load balancer or router like we have it in Heroku.