### PR TITLE
upgraded quasar dependency to version 1.0.0-beta.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "moment": "^2.24.0",
     "nodemon": "^1.18.10",
     "pg": "^7.9.0",
-    "quasar": "^1.0.0-beta.0",
+    "quasar": "1.0.0-beta.11",
     "serve-static": "^1.13.2",
     "slugify": "^1.3.4",
     "socket.io": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6704,10 +6704,10 @@ qs@6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-quasar@^1.0.0-beta.0:
-  version "1.0.0-beta.10"
-  resolved "https://registry.yarnpkg.com/quasar/-/quasar-1.0.0-beta.10.tgz#ff79b2b505e1040b4554939136fe09ad0a1302de"
-  integrity sha512-lNV9vf/zjFJtdxXfTHtUsoxNNZ6eR7Y2XiZf7XvXhuzsUJcB6ckUavynyiIEPY5EySqOI3gV8kumDQ+7MQprcg==
+quasar@1.0.0-beta.11:
+  version "1.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/quasar/-/quasar-1.0.0-beta.11.tgz#cbccd35e2a41f333492dad2cd15b8ccf5225e918"
+  integrity sha512-g6VBCNa9fwNCyrWfxi8GwpXL6qNtyynweVKT+wqMZajjvE6fQ/EwETWF2zsla1Rv9NYsTCnW6o//bQn1vcqJbw==
 
 querystring-es3@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
Upgraded Quasar precisely to version 1.0.0-beta.11 by changing the package.json file directly. 
Version 1.0.0-beta.11 seems to be the only one in which Dialog works.